### PR TITLE
consider hashset as generic list

### DIFF
--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -905,9 +905,9 @@ namespace Castle.DynamicLinqQueryBuilder
             var oType = o;
 
             if (oType.IsGenericType && ((oType.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
-                            (oType.GetGenericTypeDefinition() == typeof(ICollection<>)) ||
-                            (oType.GetGenericTypeDefinition() == typeof(List<>)) || 
-                            (oType.GetGenericTypeDefinition() == typeof(HashSet<>))))
+                                        (oType.GetGenericTypeDefinition() == typeof(ICollection<>)) ||
+                                        (oType.GetGenericTypeDefinition() == typeof(List<>)) || 
+                                        (oType.GetGenericTypeDefinition() == typeof(HashSet<>))))
                 isGenericList = true;
 
             return isGenericList;

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -905,8 +905,9 @@ namespace Castle.DynamicLinqQueryBuilder
             var oType = o;
 
             if (oType.IsGenericType && ((oType.GetGenericTypeDefinition() == typeof(IEnumerable<>)) ||
-                                        (oType.GetGenericTypeDefinition() == typeof(ICollection<>)) ||
-                                        (oType.GetGenericTypeDefinition() == typeof(List<>))))
+                            (oType.GetGenericTypeDefinition() == typeof(ICollection<>)) ||
+                            (oType.GetGenericTypeDefinition() == typeof(List<>)) || 
+                            (oType.GetGenericTypeDefinition() == typeof(HashSet<>))))
                 isGenericList = true;
 
             return isGenericList;


### PR DESCRIPTION
Hello!

I tried to filter by IN operator on field from type HashSet, I attach the data to filter on and the filter rule
```
var people = new List<Person>() {
    new Person() {
        FirstName = "Michal",
        Grades = new Dictionary<string, object> {
            ["history"] = "83"
        },
        Hobbies = new HashSet<string> { "bikinig" }
    },
    new Person() {
        FirstName = "Idan",
        Grades = new Dictionary<string, object> {
            ["history"] = "100"
        },
        Hobbies = new HashSet<string> { "hiking" }
    }
};

var rule = new JsonNetFilterRule {
    Field = "Hobbies",
    Operator = "in",
    Value = new List<string> {"basketball", "soccer"},
    Type = "string"
};

var ruleJson = JsonSerializer.Serialize(rule);
var ruleDeserialized = JsonSerializer.Deserialize<JsonNetFilterRule>(ruleJson);
var query = rule.BuildPredicate<Person>(new BuildExpressionOptions());
```

However when I running the code I get the following exception:
```
Unhandled exception. System.ArgumentException: Method 'System.String ToLower()' declared on type 'System.String' cannot be called with instance of type 'System.Collections.Generic.HashSet`1[System.String]'
   at System.Linq.Expressions.Expression.ValidateCallInstanceType(Type instanceType, MethodInfo method)
   at System.Linq.Expressions.Expression.ValidateStaticOrInstanceMethod(Expression instance, MethodInfo method)
   at System.Linq.Expressions.Expression.ValidateMethodAndGetParameters(Expression instance, MethodInfo method)
   at System.Linq.Expressions.Expression.Call(Expression instance, MethodInfo method)
   at Castle.DynamicLinqQueryBuilder.QueryBuilder.In(Type type, Object value, Expression propertyExp, BuildExpressionOptions options) in /Users/michal/repos/dynamic-linq-query-builder/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs:line 841
   at Castle.DynamicLinqQueryBuilder.QueryBuilder.BuildOperatorExpression(Expression propertyExp, IFilterRule rule, BuildExpressionOptions options, Type type) in /Users/michal/repos/dynamic-linq-query-builder/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs:line 322
   at Castle.DynamicLinqQueryBuilder.QueryBuilder.BuildExpressionTree(ParameterExpression pe, IFilterRule rule, BuildExpressionOptions options) in /Users/michal/repos/dynamic-linq-query-builder/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs:line 240
   at Castle.DynamicLinqQueryBuilder.QueryBuilder.BuildExpressionLambda[T](IFilterRule filterRule, BuildExpressionOptions options, String& parsedQuery) in /Users/michal/repos/dynamic-linq-query-builder/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs:line 184
   at Castle.DynamicLinqQueryBuilder.QueryBuilder.BuildPredicate[T](IFilterRule filterRule, BuildExpressionOptions options, String& parsedQuery) in /Users/michal/repos/dynamic-linq-query-builder/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs:line 156
   at Castle.DynamicLinqQueryBuilder.QueryBuilder.BuildPredicate[T](IFilterRule filterRule, BuildExpressionOptions options) in /Users/michal/repos/dynamic-linq-query-builder/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs:line 143
   at michal.Program.Main(String[] args) in /Users/michal/repos/dynamic-linq-query-builder/michal/Program.cs:line 110
```

after digging in I found out that HashSet type is considered as string
