### PR TITLE
Update QueryBuilderFilterRule.cs

### DIFF
--- a/Castle.DynamicLinqQueryBuilder/QueryBuilderFilterRule.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilderFilterRule.cs
@@ -65,6 +65,31 @@ namespace Castle.DynamicLinqQueryBuilder
         /// The value.
         /// </value>
         public string[] Value { get; set; }
+        
+        
+         public QueryBuilderFilterRule()
+        {
+        }
+
+        public QueryBuilderFilterRule(string json)
+        {
+            try
+            {
+                QueryBuilderFilterRule oMycustomclassname = Newtonsoft.Json.JsonConvert.DeserializeObject<QueryBuilderFilterRule>(json);
+                Condition = oMycustomclassname.Condition;
+                Field = oMycustomclassname.Field;
+                Id = oMycustomclassname.Id;
+                Input = oMycustomclassname.Input;
+                Operator = oMycustomclassname.Operator;
+                Rules = oMycustomclassname.Rules;
+                Type = oMycustomclassname.Type;
+                Value = oMycustomclassname.Value;
+            }
+            catch
+            {
+
+            }
+        }
 
         IEnumerable<IFilterRule> IFilterRule.Rules => Rules;
         object IFilterRule.Value => Value;


### PR DESCRIPTION
add constructor to QueryBuilderFilterRule that accepts a json string. this will be helpful when passing this object as a query parameter