### PR TITLE
Update QueryBuilderFilterRule.cs

### DIFF
--- a/Castle.DynamicLinqQueryBuilder/QueryBuilderFilterRule.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilderFilterRule.cs
@@ -1,5 +1,6 @@
 ﻿using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
+using Newtonsoft.Json.Linq;
 
 namespace Castle.DynamicLinqQueryBuilder
 {
@@ -66,6 +67,29 @@ namespace Castle.DynamicLinqQueryBuilder
         /// </value>
         public string[] Value { get; set; }
 
+        public QueryBuilderFilterRule()
+        {
+        }
+
+        public QueryBuilderFilterRule(string json)
+        {
+            try
+            {
+                QueryBuilderFilterRule oMycustomclassname = Newtonsoft.Json.JsonConvert.DeserializeObject<QueryBuilderFilterRule>(json);
+                Condition = oMycustomclassname.Condition;
+                Field = oMycustomclassname.Field;
+                Id = oMycustomclassname.Id;
+                Input = oMycustomclassname.Input;
+                Operator = oMycustomclassname.Operator;
+                Rules = oMycustomclassname.Rules;
+                Type = oMycustomclassname.Type;
+                Value = oMycustomclassname.Value;
+            }
+            catch
+            {
+
+            }
+        }
         IEnumerable<IFilterRule> IFilterRule.Rules => Rules;
         object IFilterRule.Value => Value;
     }


### PR DESCRIPTION
Add Constructor that accepts a json string. this is helpful when user wants to pass this object as a queryparamter with GET