### PR TITLE
Support Date for equal, in, and between along with nullable prop

### DIFF
--- a/Castle.DynamicLinqQueryBuilder.SystemTextJson/Castle.DynamicLinqQueryBuilder.SystemTextJson.csproj
+++ b/Castle.DynamicLinqQueryBuilder.SystemTextJson/Castle.DynamicLinqQueryBuilder.SystemTextJson.csproj
@@ -12,7 +12,7 @@
 	  <FileAlignment>512</FileAlignment>
 	  <TargetFrameworkProfile />
 	  <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-	  <Version>1.3.0</Version>
+	  <Version>1.3.1</Version>
 	  <Authors>Grant Hamm</Authors>
 	  <Company>N/A</Company>
 	  <Product>Dynamic Linq Query Builder - System.Text.Json Extension</Product>

--- a/Castle.DynamicLinqQueryBuilder.SystemTextJson/SystemTextJsonFilterRule.cs
+++ b/Castle.DynamicLinqQueryBuilder.SystemTextJson/SystemTextJsonFilterRule.cs
@@ -80,6 +80,8 @@ namespace Castle.DynamicLinqQueryBuilder.SystemTextJson
                     {
                         if (jsonValue.ValueKind == JsonValueKind.Array)
                         {
+                            if (myType.Name == "DateOnly")
+                                myType = typeof(DateTime);
                             var outList = Array.CreateInstance(myType, jsonValue.GetArrayLength());
                             var enumerator = 0;
 

--- a/Castle.DynamicLinqQueryBuilder.Tests/Castle.DynamicLinqQueryBuilder.Tests.csproj
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Castle.DynamicLinqQueryBuilder.Tests.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net6.0</TargetFramework>

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/JsonNetFilterRuleTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/JsonNetFilterRuleTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Diagnostics.CodeAnalysis;
 using System.Globalization;
 using System.Linq;
+using Castle.DynamicLinqQueryBuilder.Tests.CustomOperators;
 using Castle.DynamicLinqQueryBuilder.Tests.Helpers;
 using NUnit.Framework;
 
@@ -14,12 +15,14 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
     {
         IQueryable<Tests.ExpressionTreeBuilderTestClass> StartingQuery;
         IQueryable<Tests.ExpressionTreeBuilderTestClass> StartingDateQuery;
+        BuildExpressionOptions dtOptionCurrentCulture;
 
         [SetUp]
         public void Setup()
         {
             StartingQuery = Tests.GetExpressionTreeData().AsQueryable();
             StartingDateQuery = Tests.GetDateExpressionTreeData().AsQueryable();
+            dtOptionCurrentCulture = new BuildExpressionOptions() { CultureInfo = CultureInfo.CurrentCulture };
         }
 
         #region Wrapper
@@ -292,7 +295,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(lastModifiedFilterList != null);
             Assert.IsTrue(lastModifiedFilterList.Count == 4);
             Assert.IsTrue(
@@ -325,7 +328,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(nullableLastModifiedFilterList != null);
             Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
             Assert.IsTrue(
@@ -698,7 +701,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(lastModifiedFilterList != null);
             Assert.IsTrue(lastModifiedFilterList.Count == 0);
             Assert.IsTrue(
@@ -731,7 +734,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(nullableLastModifiedFilterList != null);
             Assert.IsTrue(nullableLastModifiedFilterList.Count == 1);
             Assert.IsTrue(
@@ -2260,7 +2263,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(lastModifiedFilterList != null);
             Assert.IsTrue(lastModifiedFilterList.Count == 4);
             Assert.IsTrue(
@@ -2293,7 +2296,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(nullableLastModifiedFilterList != null);
             Assert.IsTrue(nullableLastModifiedFilterList.Count == 3);
             Assert.IsTrue(
@@ -2437,7 +2440,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter).ToList();
+            var lastModifiedFilterList = StartingQuery.BuildQuery(lastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(lastModifiedFilterList != null);
             Assert.IsTrue(lastModifiedFilterList.Count == 0);
             Assert.IsTrue(
@@ -2470,7 +2473,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     }
                 }
             };
-            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter).ToList();
+            var nullableLastModifiedFilterList = StartingQuery.BuildQuery(nullableLastModifiedFilter, dtOptionCurrentCulture).ToList();
             Assert.IsTrue(nullableLastModifiedFilterList != null);
             Assert.IsTrue(nullableLastModifiedFilterList.Count == 1);
             Assert.IsTrue(

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/QueryBuilderFilterRuleTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/QueryBuilderFilterRuleTests.cs
@@ -142,6 +142,32 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
 
             });
 
+            contentIdFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
+                        Field = "LastModified",
+                        Id = "LastModified",
+                        Input = "NA",
+                        Operator = "between",
+                        Type = "date",
+                        Value = new[]
+                            {
+                                DateTime.Parse("2/21/2016", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal).ToShortDateString(),
+                                DateTime.Parse("2/23/2016", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal).ToShortDateString()
+                        }
+                    }
+                }
+            };
+            queryable = StartingDateQuery.BuildQuery(contentIdFilter, new BuildExpressionOptions() { CultureInfo = CultureInfo.CurrentCulture });
+            contentIdFilteredList2 = queryable.ToList();
+            Assert.IsTrue(contentIdFilteredList2 != null);
+            Assert.IsTrue(contentIdFilteredList2.Count == 1);
+
             QueryBuilder.ParseDatesAsUtc = false;
         }
 

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/QueryBuilderFilterRuleTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/QueryBuilderFilterRuleTests.cs
@@ -87,7 +87,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                         Input = "NA",
                         Operator = "in",
                         Type = "date",
-                        Value = new[] { "2/23/2016" }
+                        Value = new[] { "2/23/2016", "2/21/2016" }
                     }
                 }
             };
@@ -110,7 +110,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                         Input = "NA",
                         Operator = "in",
                         Type = "date",
-                        Value = new[] { "2/23/2016" }
+                        Value = new[] { "2/23/2016", "2/21/2016" }
                     }
                 }
             };

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/QueryBuilderFilterRuleTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/QueryBuilderFilterRuleTests.cs
@@ -82,6 +82,29 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     new QueryBuilderFilterRule
                     {
                         Condition = "and",
+                        Field = "NullDateList",
+                        Id = "NullDateList",
+                        Input = "NA",
+                        Operator = "in",
+                        Type = "date",
+                        Value = new[] { "2/23/2016" }
+                    }
+                }
+            };
+            queryable = StartingDateQuery.BuildQuery(contentIdFilter);
+            contentIdFilteredList = queryable.ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 0);
+
+
+            contentIdFilter = new QueryBuilderFilterRule
+            {
+                Condition = "and",
+                Rules = new List<QueryBuilderFilterRule>
+                {
+                    new QueryBuilderFilterRule
+                    {
+                        Condition = "and",
                         Field = "DateList",
                         Id = "DateList",
                         Input = "NA",

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/SystemTextJsonTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/SystemTextJsonTests.cs
@@ -482,6 +482,50 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                     new SystemTextJsonFilterRule
                     {
                         Condition = "and",
+                        Field = "LastModifiedIfPresent",
+                        Id = "LastModifiedIfPresent",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "date",
+                        Value = DateTime.UtcNow.ToString("M/dd/yyyy")
+                    }
+                }
+            };
+            queryable = StartingDateQuery.BuildQuery(contentIdFilter);
+            contentIdFilteredList = queryable.ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 1);
+
+            contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
+                        Field = "NullableLastModified",
+                        Id = "NullableLastModified",
+                        Input = "NA",
+                        Operator = "equal",
+                        Type = "date",
+                        Value = "2/23/2016"
+                    }
+                }
+            };
+            queryable = StartingDateQuery.BuildQuery(contentIdFilter);
+            contentIdFilteredList = queryable.ToList();
+            Assert.IsTrue(contentIdFilteredList != null);
+            Assert.IsTrue(contentIdFilteredList.Count == 0);
+
+            contentIdFilter = new SystemTextJsonFilterRule
+            {
+                Condition = "and",
+                Rules = new List<SystemTextJsonFilterRule>
+                {
+                    new SystemTextJsonFilterRule
+                    {
+                        Condition = "and",
                         Field = "LastModified",
                         Id = "LastModified",
                         Input = "NA",

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/SystemTextJsonTests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/SystemTextJsonTests.cs
@@ -349,6 +349,8 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
         [Test]
         public void SystemTextJsonDateHandling()
         {
+            var options = new BuildExpressionOptions() { CultureInfo = CultureInfo.CurrentCulture };
+
             QueryBuilder.ParseDatesAsUtc = true;
             var contentIdFilter = new SystemTextJsonFilterRule
             {
@@ -368,7 +370,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                 }
             };
 
-            var queryable = StartingDateQuery.BuildQuery<Rules.Tests.ExpressionTreeBuilderTestClass>(contentIdFilter);
+            var queryable = StartingDateQuery.BuildQuery(contentIdFilter, options);
             var contentIdFilteredList = queryable.ToList();
             Assert.IsTrue(contentIdFilteredList != null);
             Assert.IsTrue(contentIdFilteredList.Count == 1);
@@ -391,7 +393,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                 }
             };
 
-            var queryable2 = StartingDateQuery.BuildQuery<Rules.Tests.ExpressionTreeBuilderTestClass>(contentIdFilter2);
+            var queryable2 = StartingDateQuery.BuildQuery(contentIdFilter2, options);
             var contentIdFilteredList2 = queryable2.ToList();
             Assert.IsTrue(contentIdFilteredList2 != null);
             Assert.IsTrue(contentIdFilteredList2.Count == 1);
@@ -408,13 +410,13 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                         Id = "LastModified",
                         Input = "NA",
                         Operator = "in",
-                        Type = "datetime",
+                        Type = "date",
                         Value = JsonSerializer.SerializeToElement(new[] { DateTime.Parse("2/23/2016", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal) })
                     }
                 }
             };
 
-            var queryable3 = StartingDateQuery.BuildQuery<Rules.Tests.ExpressionTreeBuilderTestClass>(contentIdFilter3);
+            var queryable3 = StartingDateQuery.BuildQuery(contentIdFilter3, options);
             var contentIdFilteredList3 = queryable3.ToList();
             Assert.IsTrue(contentIdFilteredList3 != null);
             Assert.IsTrue(contentIdFilteredList3.Count == 1);
@@ -437,7 +439,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                 }
             };
 
-            var queryable4 = StartingDateQuery.BuildQuery<Rules.Tests.ExpressionTreeBuilderTestClass>(contentIdFilter4);
+            var queryable4 = StartingDateQuery.BuildQuery(contentIdFilter4, options);
             var contentIdFilteredList4 = queryable4.ToList();
             Assert.IsTrue(contentIdFilteredList4 != null);
             Assert.IsTrue(contentIdFilteredList4.Count == 1);

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
@@ -36,6 +36,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
             public List<int> IntList { get; set; }
             public List<int?> IntNullList { get; set; }
             public List<DateTime> DateList { get; set; }
+            public List<DateTime?> NullDateList { get { return new List<DateTime?> { null }; } }
             public List<double> DoubleList { get; set; }
             public List<string> StrList { get; set; }
             public List<ChildClass> ChildClasses { get; set; }

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
@@ -66,7 +66,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                 Flags = new List<string>(),
                 IsPossiblyNotSetBool = true,
                 IsSelected = true,
-                LastModified = DateTime.Parse("2/23/2016", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal),
+                LastModified = DateTime.Parse("2/23/2016", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal).AddHours(3),
                 LastModifiedIfPresent = DateTime.UtcNow.Date,
                 LongerTextToFilter = "There is something interesting about this text",
                 NullableContentTypeId = 1,
@@ -74,7 +74,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                 StatValue = 1.11,
                 IntList = new List<int>() { 1, 3, 5, 7 },
                 StrList = new List<string>() { "Str1", "Str2" },
-                DateList = new List<DateTime>() { DateTime.Parse("2/23/2016", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal), DateTime.UtcNow.Date.AddDays(-2) },
+                DateList = new List<DateTime>() { DateTime.Parse("2/23/2016", CultureInfo.InvariantCulture, DateTimeStyles.AdjustToUniversal).AddHours(2), DateTime.UtcNow.AddDays(-2) },
                 DoubleList = new List<double>() { 1.48, 1.84, 1.33 },
                 IntNullList = new List<int?>() { 3, 4, 5, null }
             };

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
@@ -30,6 +30,7 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
             public bool? IsPossiblyNotSetBool { get; set; }
             public DateTime LastModified { get; set; }
             public DateTime? LastModifiedIfPresent { get; set; }
+            public DateTime? NullableLastModified { get { return null; } }
             public double StatValue { get; set; }
             public double? PossiblyEmptyStatValue { get; set; }
             public List<int> IntList { get; set; }

--- a/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
+++ b/Castle.DynamicLinqQueryBuilder.Tests/Rules/Tests.cs
@@ -2660,14 +2660,14 @@ namespace Castle.DynamicLinqQueryBuilder.Tests.Rules
                         Id = "LastModified",
                         Input = "NA",
                         Operator = "in",
-                        Type = "datetime",
+                        Type = "date",
                         Value = DateTime.UtcNow.Date.AddDays(-2)
                     }
                 }
             };
             var lastModifiedFilterList = startingQuery.BuildQuery(lastModifiedFilter, new BuildExpressionOptions()
             {
-                CultureInfo = CultureInfo.InvariantCulture,
+                CultureInfo = CultureInfo.CurrentCulture,
                 ParseDatesAsUtc = true
             }).ToList();
             Assert.IsTrue(lastModifiedFilterList != null);

--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Castle.DynamicLinqQueryBuilder</RootNamespace>
     <AssemblyName>Castle.DynamicLinqQueryBuilder</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -12,7 +12,7 @@
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>
-    <Version>1.3.0</Version>
+    <Version>1.3.1</Version>
     <Authors>Grant Hamm</Authors>
     <Company>N/A</Company>
     <Product>Dynamic Linq Query Builder</Product>

--- a/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
+++ b/Castle.DynamicLinqQueryBuilder/Castle.DynamicLinqQueryBuilder.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>Castle.DynamicLinqQueryBuilder</RootNamespace>
     <AssemblyName>Castle.DynamicLinqQueryBuilder</AssemblyName>
-    <TargetFrameworks>netstandard2.0;net6</TargetFrameworks>
+    <TargetFrameworks>netstandard2.0;net6;net45</TargetFrameworks>
     <FileAlignment>512</FileAlignment>
     <TargetFrameworkProfile />
     <GeneratePackageOnBuild>true</GeneratePackageOnBuild>

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -924,7 +924,10 @@ namespace Castle.DynamicLinqQueryBuilder
                         MethodCallExpression methodCall = null;
                         if (isDtOnly)
                         {
-                            methodCall = Expression.Call(listCallExp, method, Expression.Convert(someValues[counter], genericType));
+                            methodCall = Expression.Call(
+                                ReflectionHelpers.ContainsMethod.MakeGenericMethod(typeof(DateTime)),
+                                listCallExp,
+                                Expression.Convert(someValues[counter], typeof(DateTime)));
                         }
                         else
                         {

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -9,6 +9,7 @@ using System.Linq.Expressions;
 using System.Reflection;
 using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
+using System.Xml.Schema;
 
 namespace Castle.DynamicLinqQueryBuilder
 {
@@ -858,9 +859,25 @@ namespace Castle.DynamicLinqQueryBuilder
 
         private static Expression Between(Type type, object value, Expression propertyExp, BuildExpressionOptions options)
         {
-            var someValue = GetConstants(type, value, true, options);
-
-
+            if (type.Name == "DateOnly") // value 2 must be increased by 1 day to be inclusive regarding the time portion in the property.
+            {
+                List<string> newValues = new List<string>();
+                int i = 0;
+                foreach (var item in value as IEnumerable<string>)
+                {
+                    if (i == 1)
+                    {
+                        newValues.Add(DateTime.Parse(item).AddDays(1).Date.ToString(options.CultureInfo));
+                        break;
+                    }
+                    else
+                        newValues.Add(item);
+                    i++;
+                }
+                value = newValues;
+            }
+            var someValue = GetConstants(type, value, true, options);            
+            
             Expression exBelow = Expression.GreaterThanOrEqual(propertyExp, Expression.Convert(someValue[0], propertyExp.Type));
             Expression exAbove = Expression.LessThanOrEqual(propertyExp, Expression.Convert(someValue[1], propertyExp.Type));
 

--- a/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
+++ b/Castle.DynamicLinqQueryBuilder/QueryBuilder.cs
@@ -7,6 +7,7 @@ using System.Globalization;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
+using System.Runtime.CompilerServices;
 using System.Security.Cryptography.X509Certificates;
 
 namespace Castle.DynamicLinqQueryBuilder
@@ -719,7 +720,7 @@ namespace Castle.DynamicLinqQueryBuilder
             return Expression.Not(Equals(type, value, propertyExp, options));
         }
 
-
+        // Newer .net has this class, so it can be deleted when upgrade.
         private struct DateOnly { }
         private static Expression Equals(Type type, object value, Expression propertyExp, BuildExpressionOptions options)
         {
@@ -960,7 +961,7 @@ namespace Castle.DynamicLinqQueryBuilder
                     }
                     else
                     {
-                        exOut = Expression.Equal(propertyExp, Expression.Convert(someValues.First(), propertyExp.Type));
+                        exOut = Equals(type, someValues.First(), propertyExp, options);
                     }
                 }
 

--- a/Castle.DynamicLinqQueryBuilder/ReflectionHelpers.cs
+++ b/Castle.DynamicLinqQueryBuilder/ReflectionHelpers.cs
@@ -30,19 +30,5 @@ namespace Castle.DynamicLinqQueryBuilder
 
         public static MethodInfo GetExtensionMethod(Assembly extensionsAssembly, string name)
             => GetExtensionMethods(extensionsAssembly).FirstOrDefault(m => m.Name == name);
-
-        public static MethodInfo GetExtensionMethod(Assembly extensionsAssembly, string name, Type[] types)
-        {
-            var methods = (from m in GetExtensionMethods(extensionsAssembly)
-                           where m.Name == name && m.GetParameters().Count() == types.Length + 1 // + 1 because extension method parameter (this)
-                           select m).ToList();
-
-            if (!methods.Any())
-            {
-                return default;
-            }
-
-            return methods.First(); // Not the best option.
-        }
     }
 }

--- a/Castle.DynamicLinqQueryBuilder/ReflectionHelpers.cs
+++ b/Castle.DynamicLinqQueryBuilder/ReflectionHelpers.cs
@@ -1,0 +1,44 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+
+namespace Castle.DynamicLinqQueryBuilder
+{
+    public static class ReflectionHelpers
+    {
+        public static MethodInfo SelectMethod;
+        public static MethodInfo ToListMethod;
+
+        static ReflectionHelpers()
+        {
+            SelectMethod = GetExtensionMethod(typeof(Enumerable).Assembly, "Select");
+            ToListMethod = GetExtensionMethod(typeof(Enumerable).Assembly, "ToList");
+        }
+
+        public static IEnumerable<MethodInfo> GetExtensionMethods(Assembly extensionsAssembly)
+            => from t in extensionsAssembly.GetTypes()
+               where !t.IsGenericType && !t.IsNested
+               from m in t.GetMethods(BindingFlags.Static | BindingFlags.Public | BindingFlags.NonPublic)
+               where m.IsDefined(typeof(System.Runtime.CompilerServices.ExtensionAttribute), false)
+               //where m.GetParameters()[0].ParameterType == type
+               select m;
+
+        public static MethodInfo GetExtensionMethod(Assembly extensionsAssembly, string name)
+            => GetExtensionMethods(extensionsAssembly).FirstOrDefault(m => m.Name == name);
+
+        public static MethodInfo GetExtensionMethod(Assembly extensionsAssembly, string name, Type[] types)
+        {
+            var methods = (from m in GetExtensionMethods(extensionsAssembly)
+                           where m.Name == name && m.GetParameters().Count() == types.Length + 1 // + 1 because extension method parameter (this)
+                           select m).ToList();
+
+            if (!methods.Any())
+            {
+                return default;
+            }
+
+            return methods.First(); // Not the best option.
+        }
+    }
+}

--- a/Castle.DynamicLinqQueryBuilder/ReflectionHelpers.cs
+++ b/Castle.DynamicLinqQueryBuilder/ReflectionHelpers.cs
@@ -8,11 +8,15 @@ namespace Castle.DynamicLinqQueryBuilder
     public static class ReflectionHelpers
     {
         public static MethodInfo SelectMethod;
+        public static MethodInfo WhereMethod;
+        public static MethodInfo ContainsMethod;
         public static MethodInfo ToListMethod;
 
         static ReflectionHelpers()
         {
             SelectMethod = GetExtensionMethod(typeof(Enumerable).Assembly, "Select");
+            WhereMethod = GetExtensionMethod(typeof(Enumerable).Assembly, "Where");
+            ContainsMethod = GetExtensionMethod(typeof(Enumerable).Assembly, "Contains");
             ToListMethod = GetExtensionMethod(typeof(Enumerable).Assembly, "ToList");
         }
 


### PR DESCRIPTION
Type = "date" 
Doesn't work properly when matching against DateTime properties when the time portion is not 12:00 am.
Now it's fixed for Equals, In, and Between operators along with supporting nullable properties.